### PR TITLE
[기능수정] Recipe 이미지 업로드 로직처리 변경

### DIFF
--- a/src/main/java/com/sparta/backend/domain/Recipe/Recipe.java
+++ b/src/main/java/com/sparta/backend/domain/Recipe/Recipe.java
@@ -29,7 +29,7 @@ public class Recipe extends BaseEntity {
     @Column(nullable = false)
     private String content;
 
-    private int price;
+    private Integer price;
 
     @ManyToOne(fetch = FetchType.LAZY)
     @JsonManagedReference
@@ -52,7 +52,7 @@ public class Recipe extends BaseEntity {
     @JsonBackReference
     private List<RecipeImage> recipeImagesList;
 
-    public Recipe(String title, String content, int price, User user){
+    public Recipe(String title, String content, Integer price, User user){
         //Edge케이스들 validation
         RecipeValidator.validateRecipeInput(title,content,user);
         this.title = title;
@@ -60,7 +60,7 @@ public class Recipe extends BaseEntity {
         this.price = price;
         this.user = user;
     }
-    public Recipe updateRecipe(String title, String content, int price) {
+    public Recipe updateRecipe(String title, String content, Integer price) {
         this.title = title;
         this.content = content;
         this.price = price;
@@ -69,7 +69,7 @@ public class Recipe extends BaseEntity {
     }
 
     //test용(강제 id주입 위해)
-    public Recipe(Long id, String title, String content, int price, User user){
+    public Recipe(Long id, String title, String content, Integer price, User user){
         this.id = id;
         this.title = title;
         this.content = content;

--- a/src/main/java/com/sparta/backend/dto/request/recipes/PostRecipeRequestDto.java
+++ b/src/main/java/com/sparta/backend/dto/request/recipes/PostRecipeRequestDto.java
@@ -11,21 +11,17 @@ public class PostRecipeRequestDto {
     private String content;
     private int price;
     private List<String> tag;
-    private MultipartFile image1;
-    private MultipartFile image2;
-    private MultipartFile image3;
-    private MultipartFile image4;
-    private MultipartFile image5;
+    private MultipartFile[] image;
 
-    public PostRecipeRequestDto(String title, String content, int price, List<String> tag, MultipartFile image1, MultipartFile image2, MultipartFile image3, MultipartFile image4, MultipartFile image5) {
-        this.title = title;
-        this.content = content;
-        this.price = price;
-        this.tag = tag;
-        this.image1 = image1;
-        this.image2 = image2;
-        this.image3 = image3;
-        this.image4 = image4;
-        this.image5 = image5;
-    }
+//    public PostRecipeRequestDto(String title, String content, int price, List<String> tag, MultipartFile image1, MultipartFile image2, MultipartFile image3, MultipartFile image4, MultipartFile image5) {
+//        this.title = title;
+//        this.content = content;
+//        this.price = price;
+//        this.tag = tag;
+//        this.image1 = image1;
+//        this.image2 = image2;
+//        this.image3 = image3;
+//        this.image4 = image4;
+//        this.image5 = image5;
+//    }
 }

--- a/src/main/java/com/sparta/backend/dto/request/recipes/PostRecipeRequestDto.java
+++ b/src/main/java/com/sparta/backend/dto/request/recipes/PostRecipeRequestDto.java
@@ -9,7 +9,7 @@ import java.util.List;
 public class PostRecipeRequestDto {
     private String title;
     private String content;
-    private int price;
+    private Integer price;
     private List<String> tag;
     private MultipartFile[] image;
 

--- a/src/main/java/com/sparta/backend/service/Recipe/RecipeService.java
+++ b/src/main/java/com/sparta/backend/service/Recipe/RecipeService.java
@@ -91,13 +91,15 @@ public class RecipeService {
         //게시글 존재여부확인
         Recipe recipe = recipeRepository.findById(recipeId).orElseThrow(()->new CustomErrorException("해당 게시물을 찾을 수 없습니다"));
 
+        //수정할 이미지 S3에 업로드
+        MultipartFile[] imageList = requestDto.getImage();
+        List<String> imageUrlList = uploadManyImagesToS3(requestDto,"recipeImage");
+
         //S3에 있는 사진 삭제
         for(int i=0; i<recipe.getRecipeImagesList().size();i++){
             RecipeImage recipeImage = recipe.getRecipeImagesList().get(i);
             if(recipeImage!= null) deleteS3(recipeImage.getImage());
         }
-        //S3에 이미지 업로드
-        List<String> imageUrlList= uploadManyImagesToS3(requestDto, "recipeImage");
 
         //DB의 recipe_image 기존 row들 삭제(그냥 update하면 더 작은 개수로 image업뎃할때 outOfInedex에러남)
         recipeImageRepository.deleteAllByRecipe(recipe);
@@ -109,7 +111,7 @@ public class RecipeService {
         //이미지 외 다른 내용들 수정
         String title = requestDto.getTitle();
         String content = requestDto.getContent();
-        int price = requestDto.getPrice();
+        Integer price = requestDto.getPrice();
 
         return recipe.updateRecipe(title,content,price);
     }

--- a/src/main/java/com/sparta/backend/service/Recipe/RecipeService.java
+++ b/src/main/java/com/sparta/backend/service/Recipe/RecipeService.java
@@ -23,6 +23,7 @@ import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.multipart.MultipartFile;
 
 import java.io.IOException;
 import java.time.LocalDateTime;
@@ -66,12 +67,11 @@ public class RecipeService {
     public List<String> uploadManyImagesToS3(PostRecipeRequestDto requestDto, String dirName) throws IOException {
         List<String> savedImages = new ArrayList<>();
         //s3에 이미지저장
-        if(requestDto.getImage1() != null) savedImages.add(s3Uploader.upload(requestDto.getImage1(),dirName));
-        if(requestDto.getImage2() != null) savedImages.add(s3Uploader.upload(requestDto.getImage2(),dirName));
-        if(requestDto.getImage3() != null) savedImages.add(s3Uploader.upload(requestDto.getImage3(),dirName));
-        if(requestDto.getImage4() != null) savedImages.add(s3Uploader.upload(requestDto.getImage4(),dirName));
-        if(requestDto.getImage5() != null) savedImages.add(s3Uploader.upload(requestDto.getImage5(),dirName));
-
+        for(MultipartFile img : requestDto.getImage()){
+            String imageUrl = s3Uploader.upload(img, dirName);
+            if(imageUrl == null) throw new NullPointerException("이미지를 s3에 업로드하는 과정 실패");
+            savedImages.add(imageUrl);
+        }
         return savedImages;
     }
     //여러장의 이미지를 db에 저장하는 기능


### PR DESCRIPTION
- 여러장 받을 때 Multipartfile[]로 받도록 변경하였습니다.
- 수정시에 기존 사진 삭제 후 다시 저장하도록 하였습니다.
- price가 null일때 예외가 나왔는데, null도 받을 수 있도록 수정하였습니다.

단, Entity의 칼럼을 건드렸기에 mysql ddl-auto를 create으로 한번 엎어주어야 정상작동이 될 것으로 보입니다.