### PR TITLE
[기능수정 ]레시피 목록조회 좋아요 순 추가(api수정)

### DIFF
--- a/src/main/java/com/sparta/backend/controller/BoardController.java
+++ b/src/main/java/com/sparta/backend/controller/BoardController.java
@@ -13,6 +13,7 @@ import org.springframework.data.domain.Page;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
+import javax.validation.Valid;
 import java.io.IOException;
 
 @RequiredArgsConstructor

--- a/src/main/java/com/sparta/backend/controller/RecipeController.java
+++ b/src/main/java/com/sparta/backend/controller/RecipeController.java
@@ -79,10 +79,11 @@ public class RecipeController {
                                            @RequestParam("size") int size,
                                            @RequestParam("isAsc") boolean isAsc,
                                            @RequestParam("sortBy") String sortBy,
+                                           @RequestParam("sortByLike") Boolean sortByLike,
                                            @AuthenticationPrincipal UserDetailsImpl userDetails){
         checkLogin(userDetails);
         page = page-1;
-        Page<RecipeListResponseDto> recipesByPage = recipeService.getRecipesByPage(page, size, isAsc, sortBy, userDetails);
+        Page<RecipeListResponseDto> recipesByPage = recipeService.getRecipesByPage(page, size, isAsc, sortBy,sortByLike, userDetails);
         return new CustomResponseDto<>(1, "레시피 리스트 성공", recipesByPage);
     }
 

--- a/src/main/java/com/sparta/backend/domain/User.java
+++ b/src/main/java/com/sparta/backend/domain/User.java
@@ -82,9 +82,9 @@ public class User extends BaseEntity {
 
     @Builder
     public User(String email, String password, String nickname, String image, UserRole role, String status) {
-        validateEmail(email);
-        validatePassword(password);
-        validateNickname(nickname);
+//        validateEmail(email);
+//        validatePassword(password);
+//        validateNickname(nickname);
         this.email = email;
         this.password = password;
         this.nickname = nickname;

--- a/src/main/java/com/sparta/backend/repository/RecipeRepository.java
+++ b/src/main/java/com/sparta/backend/repository/RecipeRepository.java
@@ -22,6 +22,10 @@ public interface RecipeRepository extends JpaRepository<Recipe,Long> {
     @Query("select r from Recipe r where r.title like concat('%',:keyword,'%') or r.content like concat('%',:keyword,'%')")
     Page<Recipe> findAllByTitleOrContent(String keyword, Pageable pageable);
 
+    //레시피 목록조회 좋아요 순
+    @Query("select r from Recipe r left join r.recipeLikesList l group by r.id order by count(l.recipe) desc")
+    Page<Recipe> findRecipesOrderByLikeCountDesc(Pageable pageable);
+
 //  특정기간&인기레시피 - 원하는 칼럼만 가져오는 jpql
     @Query("select r.id as recipeId, r.title as title, r.content as content , r.price as price " +
             "from Recipe r join r.recipeLikesList l " +

--- a/src/main/java/com/sparta/backend/service/Recipe/RecipeService.java
+++ b/src/main/java/com/sparta/backend/service/Recipe/RecipeService.java
@@ -153,11 +153,12 @@ public class RecipeService {
         return responsetDto;
     }
 
-    public Page<RecipeListResponseDto> getRecipesByPage(int page, int size, boolean isAsc, String sortBy, UserDetailsImpl userDetails) {
+    public Page<RecipeListResponseDto> getRecipesByPage(int page, int size, boolean isAsc, String sortBy, Boolean sortByLike ,UserDetailsImpl userDetails) {
         Sort.Direction direction = isAsc ? Sort.Direction.ASC : Sort.Direction.DESC;
         Sort sort = Sort.by(direction, sortBy);
         Pageable pageable = PageRequest.of(page,size,sort);
-        Page<Recipe> recipes = recipeRepository.findAll(pageable);
+
+        Page<Recipe> recipes = sortByLike? recipeRepository.findRecipesOrderByLikeCountDesc(pageable): recipeRepository.findAll(pageable);
 
         Page<RecipeListResponseDto> responseDtos = recipes.map((recipe)->new RecipeListResponseDto(recipe, userDetails,recipeLikesRepository));
 


### PR DESCRIPTION
1. 레시피 목록을 최신순으로만 조회를 했으나, 좋아요 순도 추가하였습니다.

따라서 api도 수정하였습니다.

예시)
http://localhost:8080/recipes/list?page=1&size=10&isAsc=false&sortBy=regDate&sortByLike=true

마지막 sortByLike=true or false로 주는 것을 추가하였습니다.

2. 또한, 기존 dev가 회원가입이 되지 않는 상황이라 주석처리한 부분이 있습니다. 머지시 필요한 것으로 수정하시면 될 것 같습니다.