### PR TITLE
[기능수정] 레시피 수정로직 변경

### DIFF
--- a/src/main/java/com/sparta/backend/controller/RecipeController.java
+++ b/src/main/java/com/sparta/backend/controller/RecipeController.java
@@ -2,6 +2,7 @@ package com.sparta.backend.controller;
 
 import com.sparta.backend.domain.recipe.Recipe;
 import com.sparta.backend.dto.request.recipes.PostRecipeRequestDto;
+import com.sparta.backend.dto.request.recipes.PutRecipeRequestDto;
 import com.sparta.backend.dto.response.CustomResponseDto;
 import com.sparta.backend.dto.response.recipes.RecipeDetailResponsetDto;
 import com.sparta.backend.dto.response.recipes.RecipeListResponseDto;
@@ -52,7 +53,7 @@ public class RecipeController {
 
     //레시피 수정
     @PutMapping("/recipes/{recipeId}")
-    public CustomResponseDto<?> updateRecipe(@PathVariable Long recipeId, PostRecipeRequestDto requestDto, @AuthenticationPrincipal UserDetailsImpl userDetails) throws IOException {
+    public CustomResponseDto<?> updateRecipe(@PathVariable Long recipeId, PutRecipeRequestDto requestDto, @AuthenticationPrincipal UserDetailsImpl userDetails) throws IOException {
         //todo:IOException처리
         checkLogin(userDetails);
         checkOwnership(recipeId, userDetails);

--- a/src/main/java/com/sparta/backend/dto/request/recipes/PutRecipeRequestDto.java
+++ b/src/main/java/com/sparta/backend/dto/request/recipes/PutRecipeRequestDto.java
@@ -1,0 +1,18 @@
+package com.sparta.backend.dto.request.recipes;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.util.List;
+
+@Getter
+@AllArgsConstructor
+public class PutRecipeRequestDto {
+    private String title;
+    private String content;
+    private Integer price;
+    private List<String> tag;
+    private MultipartFile[] image;
+    private List<String> deleteImage;
+}

--- a/src/main/java/com/sparta/backend/repository/RecipeImageRepository.java
+++ b/src/main/java/com/sparta/backend/repository/RecipeImageRepository.java
@@ -3,8 +3,11 @@ package com.sparta.backend.repository;
 import com.sparta.backend.domain.recipe.Recipe;
 import com.sparta.backend.domain.recipe.RecipeImage;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+
+import java.util.List;
 
 public interface RecipeImageRepository extends JpaRepository<RecipeImage,Long> {
-//    @Query("delete r. from Recipe r where r.recipe_id = :recipe_id")
-    void deleteAllByRecipe(Recipe recipe);
+//    @Query("delete from RecipeImage i where i.image in :imageUrls")
+    void deleteByImageIn(List<String> imageUrls);
 }

--- a/src/test/java/com/sparta/backend/integration/RecipeIntegrationTest.java
+++ b/src/test/java/com/sparta/backend/integration/RecipeIntegrationTest.java
@@ -4,6 +4,7 @@ import com.sparta.backend.domain.User;
 import com.sparta.backend.domain.UserRole;
 import com.sparta.backend.domain.recipe.Recipe;
 import com.sparta.backend.dto.request.recipes.PostRecipeRequestDto;
+import com.sparta.backend.dto.request.recipes.PutRecipeRequestDto;
 import com.sparta.backend.dto.request.user.SignupRequestDto;
 import com.sparta.backend.security.UserDetailsImpl;
 import com.sparta.backend.service.UserService;
@@ -135,9 +136,10 @@ public class RecipeIntegrationTest {
         List<String> tag = Arrays.asList("가가,나나,다다");
         MockMultipartFile image1 = new MockMultipartFile("image", "imagefile.jpeg", "image/jpg", new FileInputStream("src/test/java/com/sparta/backend/images/puppy1.jpg"));
         MockMultipartFile[] image = {image1};
+        List<String> deleteimage = Arrays.asList("url1,url2");
 
-        PostRecipeRequestDto requestDto = new PostRecipeRequestDto(
-                title, content, price,tag, image
+        PutRecipeRequestDto requestDto = new PutRecipeRequestDto(
+                title, content, price,tag, image,deleteimage
         );
 
         //when


### PR DESCRIPTION
기존: 사용자가 기존사진을 다시 보내지 않을 경우, 모두 삭제되었었음

현재: 사용자가 기존사진을 다시 보내지 않아도, 그 사진이 유지됨. 삭제할 사진만 지정하면 삭제됨.
