### PR TITLE
[예외처리]수정시  사진 5장 넘을 경우 예외처리, 다른게시물 사진 수정 예외처리

### DIFF
--- a/src/main/java/com/sparta/backend/repository/RecipeImageRepository.java
+++ b/src/main/java/com/sparta/backend/repository/RecipeImageRepository.java
@@ -10,4 +10,6 @@ import java.util.List;
 public interface RecipeImageRepository extends JpaRepository<RecipeImage,Long> {
 //    @Query("delete from RecipeImage i where i.image in :imageUrls")
     void deleteByImageIn(List<String> imageUrls);
+
+    List<RecipeImage> findByImageIn(List<String> imageUrls);
 }

--- a/src/main/java/com/sparta/backend/repository/RecipeRepository.java
+++ b/src/main/java/com/sparta/backend/repository/RecipeRepository.java
@@ -81,6 +81,5 @@ public interface RecipeRepository extends JpaRepository<Recipe,Long> {
     Page<Recipe> findAllByRecipeLikesList(@Param("userId") Long userId, Pageable pageable);
 
     //최근레시피(메인페이지) top4가져오기
-//    @Query("select r from Recipe r order by r.regDate")
     List<Recipe> findTop4ByOrderByRegDateDesc();
 }


### PR DESCRIPTION
레시피 수정시 사진추가를 하여 총 사진이 5장이 넘을 경우 예외처리 추가
이미지 url만 알면 다른 게시물의 사진도 삭제할 수 있던 것 예외처리 추가