### PR TITLE
[기능수정] 게시물 관련 response 멘트 수정

### DIFF
--- a/src/main/java/com/sparta/backend/controller/board/BoardCommentController.java
+++ b/src/main/java/com/sparta/backend/controller/board/BoardCommentController.java
@@ -4,6 +4,7 @@ import com.sparta.backend.dto.response.board.GetBoardCommentResponseDto;
 import com.sparta.backend.dto.request.board.PostBoardCommentRequestDto;
 import com.sparta.backend.dto.request.board.PutBoardCommentRequestDto;
 import com.sparta.backend.dto.response.CustomResponseDto;
+import com.sparta.backend.exception.CustomErrorException;
 import com.sparta.backend.security.UserDetailsImpl;
 import com.sparta.backend.service.board.BoardCommentService;
 import lombok.RequiredArgsConstructor;
@@ -23,6 +24,7 @@ public class BoardCommentController {
     @PostMapping("/boards/comments")
     public ResponseEntity<?> createComment(@RequestBody PostBoardCommentRequestDto requestDto,
                                            @AuthenticationPrincipal UserDetailsImpl userDetails) {
+        checkLogin(userDetails);
         GetBoardCommentResponseDto responseDto = boardCommentService.createComment(requestDto, userDetails);
 
         if(responseDto != null) {
@@ -39,6 +41,7 @@ public class BoardCommentController {
                                             @RequestParam int page, @RequestParam int size,
                                             @RequestParam boolean isAsc, @RequestParam String sortBy,
                                             @AuthenticationPrincipal UserDetailsImpl userDetails) {
+        checkLogin(userDetails);
         Page<GetBoardCommentResponseDto> responseDto =
                 boardCommentService.getComments(id, page, size, isAsc, sortBy, userDetails);
 
@@ -54,6 +57,7 @@ public class BoardCommentController {
     public ResponseEntity<?> updateComment(@PathVariable("commentId") Long id,
                                               @RequestBody PutBoardCommentRequestDto requestDto,
                                               @AuthenticationPrincipal UserDetailsImpl userDetails) {
+        checkLogin(userDetails);
         GetBoardCommentResponseDto responseDto = boardCommentService.updateComment(id, requestDto, userDetails);
 
         if(responseDto != null) {
@@ -68,6 +72,7 @@ public class BoardCommentController {
     @DeleteMapping("/boards/comments/{commentId}")
     public ResponseEntity<?> deleteComment(@PathVariable("commentId") Long id,
                                               @AuthenticationPrincipal UserDetailsImpl userDetails) {
+        checkLogin(userDetails);
         Long boardCommentId = boardCommentService.deleteComment(id, userDetails);
 
         if(boardCommentId > 0) {
@@ -76,4 +81,12 @@ public class BoardCommentController {
             return new ResponseEntity<>(new CustomResponseDto<>(-1, "댓글 삭제 실패", ""), HttpStatus.BAD_REQUEST);
         }
     }
+
+    //로그인 확인
+    private void checkLogin(@AuthenticationPrincipal UserDetailsImpl userDetails) {
+        if (userDetails == null) {
+            throw new CustomErrorException("로그인된 유저만 사용가능한 기능입니다.");
+        }
+    }
+
 }

--- a/src/main/java/com/sparta/backend/controller/board/BoardCommentLikesController.java
+++ b/src/main/java/com/sparta/backend/controller/board/BoardCommentLikesController.java
@@ -1,6 +1,7 @@
 package com.sparta.backend.controller.board;
 
 import com.sparta.backend.dto.response.CustomResponseDto;
+import com.sparta.backend.exception.CustomErrorException;
 import com.sparta.backend.security.UserDetailsImpl;
 import com.sparta.backend.service.board.BoardCommentLikesService;
 import lombok.RequiredArgsConstructor;
@@ -21,6 +22,7 @@ public class BoardCommentLikesController {
     @PostMapping("/boards/comments/likes/{boardCommentId}")
     public ResponseEntity<?> likeBoardComment(@PathVariable("boardCommentId") Long id,
                                               @AuthenticationPrincipal UserDetailsImpl userDetails) {
+        checkLogin(userDetails);
         String boardCommentLikesMessage = boardCommentLikesService.likeBoardComment(id, userDetails);
 
         if(boardCommentLikesMessage != null || boardCommentLikesMessage.length() > 0) {
@@ -29,5 +31,12 @@ public class BoardCommentLikesController {
             return new ResponseEntity<>(new CustomResponseDto<>(-1, "게시물 좋아요/취소 실패", ""), HttpStatus.BAD_REQUEST);
         }
 
+    }
+
+    //로그인 확인
+    private void checkLogin(@AuthenticationPrincipal UserDetailsImpl userDetails) {
+        if (userDetails == null) {
+            throw new CustomErrorException("로그인된 유저만 사용가능한 기능입니다.");
+        }
     }
 }

--- a/src/main/java/com/sparta/backend/controller/board/BoardController.java
+++ b/src/main/java/com/sparta/backend/controller/board/BoardController.java
@@ -6,6 +6,7 @@ import com.sparta.backend.dto.request.board.PutBoardRequestDto;
 import com.sparta.backend.dto.response.CustomResponseDto;
 import com.sparta.backend.dto.response.board.GetBoardDetailResponseDto;
 import com.sparta.backend.dto.response.board.GetBoardResponseDto;
+import com.sparta.backend.exception.CustomErrorException;
 import com.sparta.backend.security.UserDetailsImpl;
 import com.sparta.backend.service.board.BoardService;
 import lombok.RequiredArgsConstructor;
@@ -27,7 +28,7 @@ public class BoardController {
     @PostMapping("/boards")
     public ResponseEntity<?> createBoard(PostBoardRequestDto requestDto,
                                             @AuthenticationPrincipal UserDetailsImpl userDetails) throws IOException {
-
+        checkLogin(userDetails);
         Long boardId = boardService.createBoard(requestDto, userDetails);
 
         if(boardId > 0) {
@@ -42,7 +43,7 @@ public class BoardController {
     public ResponseEntity<?> getBoards(@RequestParam int page, @RequestParam int size,
                                           @RequestParam boolean isAsc, @RequestParam String sortBy,
                                           @AuthenticationPrincipal UserDetailsImpl userDetails) {
-
+        checkLogin(userDetails);
         Page<GetBoardResponseDto> boardList =  boardService.getBoards(page, size, isAsc, sortBy, userDetails);
 
         if(boardList != null && boardList.getSize() > 0) {
@@ -56,6 +57,7 @@ public class BoardController {
     @GetMapping("/boards/{boardId}")
     public ResponseEntity<?> getBoardDetail(@PathVariable("boardId") Long id,
                                                @AuthenticationPrincipal UserDetailsImpl userDetails) {
+        checkLogin(userDetails);
         GetBoardDetailResponseDto responseDto = boardService.getBoardDetail(id, userDetails);
 
         if(responseDto != null) {
@@ -70,6 +72,7 @@ public class BoardController {
     public ResponseEntity<?> updateBoard(@PathVariable("boardId") Long id,
                                             PutBoardRequestDto requestDto,
                                             @AuthenticationPrincipal UserDetailsImpl userDetails) {
+        checkLogin(userDetails);
         try {
             Board board = boardService.updateBoard(id, requestDto, userDetails);
             if(board != null) {
@@ -87,6 +90,7 @@ public class BoardController {
     @DeleteMapping("/boards/{boardId}")
     public ResponseEntity<?> deleteBoard(@PathVariable("boardId") Long id,
                                             @AuthenticationPrincipal UserDetailsImpl userDetails) {
+        checkLogin(userDetails);
         Long boardId = boardService.deleteBoard(id, userDetails);
 
         if(boardId > 0) {
@@ -101,6 +105,7 @@ public class BoardController {
     public ResponseEntity<?> searchBoards(@RequestParam String keyword, @RequestParam int page, @RequestParam int size,
                                              @RequestParam boolean isAsc, @RequestParam String sortBy,
                                              @AuthenticationPrincipal UserDetailsImpl userDetails) {
+        checkLogin(userDetails);
         Page<GetBoardResponseDto> boardList =  boardService.searchBoards(keyword, page, size, isAsc, sortBy, userDetails);
 
         if(boardList != null && boardList.getSize() > 0) {
@@ -109,5 +114,12 @@ public class BoardController {
             return new ResponseEntity<>(new CustomResponseDto<>(-1, "게시물 검색 실패", ""), HttpStatus.BAD_REQUEST);
         }
 
+    }
+
+    //로그인 확인
+    private void checkLogin(@AuthenticationPrincipal UserDetailsImpl userDetails) {
+        if (userDetails == null) {
+            throw new CustomErrorException("로그인된 유저만 사용가능한 기능입니다.");
+        }
     }
 }

--- a/src/main/java/com/sparta/backend/controller/board/BoardLikesController.java
+++ b/src/main/java/com/sparta/backend/controller/board/BoardLikesController.java
@@ -1,6 +1,7 @@
 package com.sparta.backend.controller.board;
 
 import com.sparta.backend.dto.response.CustomResponseDto;
+import com.sparta.backend.exception.CustomErrorException;
 import com.sparta.backend.security.UserDetailsImpl;
 import com.sparta.backend.service.board.BoardLikesService;
 import lombok.RequiredArgsConstructor;
@@ -19,12 +20,20 @@ public class BoardLikesController {
     @PostMapping("/boards/likes/{boardId}")
     public ResponseEntity<?> likeBoard(@PathVariable("boardId") Long id,
                                        @AuthenticationPrincipal UserDetailsImpl userDetails) {
+        checkLogin(userDetails);
         String boardLikesMessage = boardLikesService.likeBoard(id, userDetails);
 
         if(boardLikesMessage != null || boardLikesMessage.length() > 0) {
             return new ResponseEntity<>(new CustomResponseDto<>(1, boardLikesMessage, ""), HttpStatus.OK);
         } else {
             return new ResponseEntity<>(new CustomResponseDto<>(-1, "게시물 좋아요/취소 실패", ""), HttpStatus.BAD_REQUEST);
+        }
+    }
+
+    //로그인 확인
+    private void checkLogin(@AuthenticationPrincipal UserDetailsImpl userDetails) {
+        if (userDetails == null) {
+            throw new CustomErrorException("로그인된 유저만 사용가능한 기능입니다.");
         }
     }
 }

--- a/src/main/java/com/sparta/backend/service/board/BoardCommentLikesService.java
+++ b/src/main/java/com/sparta/backend/service/board/BoardCommentLikesService.java
@@ -3,6 +3,7 @@ package com.sparta.backend.service.board;
 import com.sparta.backend.domain.board.BoardComment;
 import com.sparta.backend.domain.board.BoardCommentLike;
 import com.sparta.backend.domain.user.User;
+import com.sparta.backend.exception.CustomErrorException;
 import com.sparta.backend.repository.board.BoardCommentLikesRepository;
 import com.sparta.backend.repository.board.BoardCommentRepository;
 import com.sparta.backend.security.UserDetailsImpl;
@@ -21,27 +22,22 @@ public class BoardCommentLikesService {
     //게시물 댓글 좋아요/취소
     @Transactional
     public String likeBoardComment(Long id, UserDetailsImpl userDetails) {
-        if(userDetails != null) {
-            User user = userDetails.getUser();
+        User user = userDetails.getUser();
 
-            BoardComment boardComment = boardCommentRepository.findById(id).orElseThrow(
-                    () -> new NullPointerException("찾는 댓글이 없습니다.")
-            );
+        BoardComment boardComment = boardCommentRepository.findById(id).orElseThrow(
+                () -> new CustomErrorException("해당 댓글이 존재하지 않습니다")
+        );
 
-            BoardCommentLike boardCommentLike =
-                    boardCommentLikesRepository.findByBoardCommentAndUser(boardComment, user);
+        BoardCommentLike boardCommentLike =
+                boardCommentLikesRepository.findByBoardCommentAndUser(boardComment, user);
 
-            if(boardCommentLike != null) {
-                boardCommentLikesRepository.deleteByBoardCommentAndUser(boardComment, user);
-                return "댓글에 좋아요 취소하였습니다.";
-            } else {
-                BoardCommentLike newBoardCommentLike = new BoardCommentLike(user, boardComment);
-                boardCommentLikesRepository.save(newBoardCommentLike);
-                return "댓글에 좋아요 하였습니다.";
-            }
-
+        if(boardCommentLike != null) {
+            boardCommentLikesRepository.deleteByBoardCommentAndUser(boardComment, user);
+            return "댓글에 좋아요 취소하였습니다.";
         } else {
-            throw new NullPointerException("로그인이 필요합니다.");
+            BoardCommentLike newBoardCommentLike = new BoardCommentLike(user, boardComment);
+            boardCommentLikesRepository.save(newBoardCommentLike);
+            return "댓글에 좋아요 하였습니다.";
         }
     }
 }

--- a/src/main/java/com/sparta/backend/service/board/BoardCommentService.java
+++ b/src/main/java/com/sparta/backend/service/board/BoardCommentService.java
@@ -6,6 +6,7 @@ import com.sparta.backend.domain.user.User;
 import com.sparta.backend.dto.response.board.GetBoardCommentResponseDto;
 import com.sparta.backend.dto.request.board.PostBoardCommentRequestDto;
 import com.sparta.backend.dto.request.board.PutBoardCommentRequestDto;
+import com.sparta.backend.exception.CustomErrorException;
 import com.sparta.backend.repository.board.BoardCommentLikesRepository;
 import com.sparta.backend.repository.board.BoardCommentRepository;
 import com.sparta.backend.repository.board.BoardRepository;
@@ -32,11 +33,10 @@ public class BoardCommentService {
     public GetBoardCommentResponseDto createComment(PostBoardCommentRequestDto requestDto,
                               UserDetailsImpl userDetails) {
         Long boardId = requestDto.getBoardId();
-        loginCheck(userDetails);    //로그인했는지 확인
         User currentLoginUser = userDetails.getUser();
 
         Board board = boardRepository.findById(boardId).orElseThrow(
-                () -> new NullPointerException("찾는 게시물이 없습니다.")
+                () -> new CustomErrorException("해당 게시물을 찾을 수 없습니다")
         );
 
         GetBoardCommentResponseDto responseDto = null;
@@ -53,7 +53,6 @@ public class BoardCommentService {
     //댓글 조회
     public Page<GetBoardCommentResponseDto> getComments(Long id, int page, int size, boolean isAsc,
                                                         String sortBy, UserDetailsImpl userDetails) {
-        loginCheck(userDetails);    //로그인했는지 확인
         //현재 페이지
         page = page - 1;
         //정렬 기준
@@ -64,7 +63,7 @@ public class BoardCommentService {
         Pageable pageable = PageRequest.of(page, size, sort);
 
         Board board = boardRepository.findById(id).orElseThrow(
-                () -> new NullPointerException("찾는 게시물이 없습니다.")
+                () -> new CustomErrorException("해당 게시물을 찾을 수 없습니다")
         );
 
         Page<BoardComment> boardCommentList = boardCommentRepository.findAllByBoard(board, pageable);
@@ -79,11 +78,10 @@ public class BoardCommentService {
     //댓글 수정
     @Transactional
     public GetBoardCommentResponseDto updateComment(Long id, PutBoardCommentRequestDto requestDto, UserDetailsImpl userDetails) {
-        loginCheck(userDetails);    //로그인했는지 확인
         Long currentLoginUser = userDetails.getUser().getId();
 
         BoardComment boardComment = boardCommentRepository.findById(id).orElseThrow(
-                () -> new NullPointerException("찾는 댓글이 없습니다.")
+                () -> new CustomErrorException("해당 댓글이 존재하지 않습니다")
         );
 
         GetBoardCommentResponseDto responseDto = null;
@@ -102,11 +100,10 @@ public class BoardCommentService {
     //댓글 삭제
     @Transactional
     public Long deleteComment(Long id, UserDetailsImpl userDetails) {
-        loginCheck(userDetails);    //로그인했는지 확인
         Long currentLoginUser = userDetails.getUser().getId();
 
         BoardComment boardComment = boardCommentRepository.findById(id).orElseThrow(
-                () -> new NullPointerException("찾는 댓글이 없습니다.")
+                () -> new CustomErrorException("해당 댓글이 존재하지 않습니다")
         );
         Long writeUser = boardComment.getUser().getId();
 
@@ -116,17 +113,10 @@ public class BoardCommentService {
         return id;
     }
 
-    //로그인 되어있는지 확인하기
-    private void loginCheck(UserDetailsImpl userDetails) {
-        if(userDetails == null) {   //로그인 안 했을 떄
-            throw new NullPointerException("로그인이 필요합니다.");
-        }
-    }
-
     //로그인한 계정이 작성자가 맞는지 확인하기
     private void writterCheck(Long currentLoginUserId, Long writeUserId) {
         if (!currentLoginUserId.equals(writeUserId)) {  //로그인한 계정이 작성자가 아닐 때
-            throw new IllegalArgumentException("해당 댓글을 작성한 사용자만 수정 가능합니다.");
+            throw new CustomErrorException("본인의 게시물만 수정,삭제 가능합니다.");
         }
     }
 }

--- a/src/main/java/com/sparta/backend/service/board/BoardLikesService.java
+++ b/src/main/java/com/sparta/backend/service/board/BoardLikesService.java
@@ -3,6 +3,7 @@ package com.sparta.backend.service.board;
 import com.sparta.backend.domain.board.Board;
 import com.sparta.backend.domain.board.BoardLike;
 import com.sparta.backend.domain.user.User;
+import com.sparta.backend.exception.CustomErrorException;
 import com.sparta.backend.repository.board.BoardLikesRepository;
 import com.sparta.backend.repository.board.BoardRepository;
 import com.sparta.backend.security.UserDetailsImpl;
@@ -22,11 +23,10 @@ public class BoardLikesService {
     @Transactional
     public String likeBoard(Long id, UserDetailsImpl userDetails) {
 
-        if(userDetails != null) {
             User user = userDetails.getUser();
 
             Board board = boardRepository.findById(id).orElseThrow(
-                    () -> new NullPointerException("찾는 게시물이 없습니다.")
+                    () -> new CustomErrorException("해당 게시물을 찾을 수 없습니다")
             );
 
             BoardLike boardLike = boardLikesRepository.findByBoardAndUser(board, user);
@@ -39,9 +39,5 @@ public class BoardLikesService {
                 boardLikesRepository.save(newBoardLike);
                 return "게시물에 좋아요 하였습니다.";
             }
-
-        } else {
-            throw new NullPointerException("로그인이 필요합니다.");
-        }
     }
 }


### PR DESCRIPTION
- 레시피와 response하는 멘트를 통일시킴
- Controller에서 로그인 체크하는 함수 생성 및 호출

프론트에서 response하는 멘트를 통일시켜달라고 요청하셔서 수정했습니다.
토큰이 없거나 로그인이 안 되어있을 때 response하는 멘트를 통일시켜달라고 하셨는데
전체적으로 멘트의 통일성이 있어야 하나의 프로젝트 느낌이 날 것 같아
게시물 쪽은 레시피 쪽과 최대한 통일시켰습니다.