### PR TITLE
[기능수정] 게시판 이미지 엔티티 길이 제한 조정

### DIFF
--- a/src/main/java/com/sparta/backend/domain/board/BoardImage.java
+++ b/src/main/java/com/sparta/backend/domain/board/BoardImage.java
@@ -19,6 +19,7 @@ public class BoardImage extends BaseEntity {
     @Column(name = "image_id")
     private Long id;
 
+    @Column(length = 600)
     private String image;
 
     @ManyToOne(fetch = FetchType.LAZY)


### PR DESCRIPTION
- 이미지 파일 이름에 길이 제한이 추가된 것에 따라 게시판 이미지 엔티티의 길이 조정