### PR TITLE
[기능수정] 게시판쪽 수정 API에 validator 추가, 게시판 검색 SQL 수정

### DIFF
--- a/src/main/java/com/sparta/backend/domain/board/Board.java
+++ b/src/main/java/com/sparta/backend/domain/board/Board.java
@@ -62,6 +62,7 @@ public class Board extends BaseEntity {
     }
 
     public Board updateBoard(String title, String content) {
+        BoardValidator.boardTitleContentValidator(title, content);
         this.title = title;
         this.content = content;
         return this;

--- a/src/main/java/com/sparta/backend/domain/board/BoardComment.java
+++ b/src/main/java/com/sparta/backend/domain/board/BoardComment.java
@@ -6,15 +6,13 @@ import com.sparta.backend.domain.BaseEntity;
 import com.sparta.backend.domain.user.User;
 import com.sparta.backend.dto.request.board.PostBoardCommentRequestDto;
 import com.sparta.backend.dto.request.board.PutBoardCommentRequestDto;
+import com.sparta.backend.validator.BoardCommentValidator;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.ToString;
 
 import javax.persistence.*;
 import java.util.List;
-
-import static com.sparta.backend.validator.BoardCommentValidator.boardCommentValidatorId;
-import static com.sparta.backend.validator.BoardCommentValidator.boardCommentValidatorRequestDto;
 
 @ToString(exclude = {"user", "board"})
 @Getter
@@ -44,14 +42,14 @@ public class BoardComment extends BaseEntity {
     private List<BoardCommentLike> boardCommentLikeList;
 
     public BoardComment(PostBoardCommentRequestDto requestDto, Board board, User user) {
-        boardCommentValidatorRequestDto(requestDto, board, user);
+        BoardCommentValidator.boardCommentValidatorRequestDto(requestDto, board, user);
         this.content = requestDto.getContent();
         this.board = board;
         this.user = user;
     }
 
     public BoardComment(Long id, PostBoardCommentRequestDto requestDto, Board board, User user) {
-        boardCommentValidatorId(id, requestDto, board, user);
+        BoardCommentValidator.boardCommentValidatorId(id, requestDto, board, user);
         this.id = id;
         this.content = requestDto.getContent();
         this.board = board;
@@ -59,7 +57,9 @@ public class BoardComment extends BaseEntity {
     }
 
     public BoardComment updateComment(PutBoardCommentRequestDto requestDto) {
-        this.content = requestDto.getContent();
+        content = requestDto.getContent();
+        BoardCommentValidator.boardCommentContentValidator(content);
+        this.content = content;
         return this;
     }
 }

--- a/src/main/java/com/sparta/backend/repository/board/BoardRepository.java
+++ b/src/main/java/com/sparta/backend/repository/board/BoardRepository.java
@@ -12,7 +12,9 @@ import org.springframework.stereotype.Repository;
 @Repository
 public interface BoardRepository extends JpaRepository<Board, Long> {
     Page<Board> findAll(Pageable pageable);
-    Page<Board> findAllByTitleContainingOrContentContaining(String title, String content, Pageable pageable);
+    @Query("select b from Board b " +
+           "where b.title like %:keyword% or b.content like %:keyword% or b.user.nickname like %:keyword% ")
+    Page<Board> findAllByTitleContainingOrContentContainingOrNicknameContaining(@Param("keyword") String keyword, Pageable pageable);
 
     Page<Board> findAllByUser(Pageable pageable, User user);
 
@@ -26,7 +28,7 @@ public interface BoardRepository extends JpaRepository<Board, Long> {
     //검색(인기순)
     @Query("select b from Board b " +
            "left join b.boardLikeList bl " +
-           "where b.title like %:keyword% or b.content like %:keyword% " +
+           "where b.title like %:keyword% or b.content like %:keyword% or b.user.nickname like %:keyword% " +
            "group by b.id order by count(bl.user) desc")
     Page<Board> findBoardsByTitleContainingOrContentContainingOrderByLikeCountDesc(@Param("keyword") String keyword,
                                                                                    Pageable pageable);

--- a/src/main/java/com/sparta/backend/service/board/BoardService.java
+++ b/src/main/java/com/sparta/backend/service/board/BoardService.java
@@ -234,7 +234,7 @@ public class BoardService {
                     boardRepository.findBoardsByTitleContainingOrContentContainingOrderByLikeCountDesc(keyword, pageable);
         } else {
             //키워드가 제목 또는 내용에 포함되어있어야 검색 결과에 나타남
-            boardList = boardRepository.findAllByTitleContainingOrContentContaining(keyword, keyword, pageable);
+            boardList = boardRepository.findAllByTitleContainingOrContentContainingOrNicknameContaining(keyword, pageable);
         }
 
         //Page<Board> -> Page<Dto> 로 변환

--- a/src/main/java/com/sparta/backend/validator/BoardCommentValidator.java
+++ b/src/main/java/com/sparta/backend/validator/BoardCommentValidator.java
@@ -20,16 +20,7 @@ public class BoardCommentValidator {
     }
 
     public static void boardCommentValidator(String content, Board board, User user) {
-        //내용
-        if(content == null) {
-            throw new NullPointerException("내용을 입력하세요");
-        } else {
-            if(content.length() <= 0) {
-                throw new NullPointerException("내용을 입력하세요");
-            } else if(content.length() > 1000) {
-                throw new IllegalArgumentException("내용은 최대 1000글자 입력 가능합니다.");
-            }
-        }
+        boardCommentContentValidator(content);
 
         //게시물
         if(board == null) {
@@ -55,5 +46,18 @@ public class BoardCommentValidator {
             }
         }
 
+    }
+
+    public static void boardCommentContentValidator(String content) {
+        //내용
+        if(content == null) {
+            throw new NullPointerException("내용을 입력하세요");
+        } else {
+            if(content.length() <= 0) {
+                throw new NullPointerException("내용을 입력하세요");
+            } else if(content.length() > 200) {
+                throw new IllegalArgumentException("내용은 최대 200글자 입력 가능합니다.");
+            }
+        }
     }
 }

--- a/src/main/java/com/sparta/backend/validator/BoardValidator.java
+++ b/src/main/java/com/sparta/backend/validator/BoardValidator.java
@@ -19,6 +19,19 @@ public class BoardValidator {
 
 
     public static void boardValidator(String title, String content, User user) {
+        boardTitleContentValidator(title, content);
+
+        //사용자
+        if(user == null || user.getId() == null) {
+            throw new NullPointerException("로그인이 필요합니다.");
+        } else {
+            if(user.getId() <= 0) {
+                throw new IllegalArgumentException("존재하지 않는 사용자입니다.");
+            }
+        }
+    }
+
+    public static void boardTitleContentValidator(String title, String content) {
         //제목
         if(title == null) { //request에서 title 자체가 없을 때
             throw new NullPointerException("제목을 입력해주세요.");
@@ -40,15 +53,6 @@ public class BoardValidator {
             }
             if(content.length() > 1000) {
                 throw new IllegalArgumentException("내용은 최대 1000글자 입력 가능합니다.");
-            }
-        }
-
-        //사용자
-        if(user == null || user.getId() == null) {
-            throw new NullPointerException("로그인이 필요합니다.");
-        } else {
-            if(user.getId() <= 0) {
-                throw new IllegalArgumentException("존재하지 않는 사용자입니다.");
             }
         }
     }


### PR DESCRIPTION
- 게시물/ 댓글 수정 함수에 validator 추가
- 게시판 댓글 글자 200자로 제한
- 게시물 검색 로직 제목/내용/닉네임 다 검색되도록 수정